### PR TITLE
refactor: 重構 task_list

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,77 +1,129 @@
-use std::env::{self, Args};
-use std::iter::Skip;
+use std::env;
+use std::io;
+use std::io::ErrorKind;
 use task_tracker::task::{Status, Task};
 use task_tracker::task_list::TaskList;
 
-fn main() {
-    let rest_args = env::args().skip(2);
-    match env::args().nth(1) {
-        Some(command) => {
-            handle_command(&command, rest_args);
-        }
+const TASK_LIST_PATH: &str = "tasks.json";
+
+fn main() -> Result<(), io::Error> {
+    initial_task_list()?;
+    let mut args = env::args().skip(1);
+
+    match args.next() {
+        Some(command) => execute_command(&command, &mut args),
         None => {
             println!("No command provided...");
+            Ok(())
         }
-    };
+    }
 }
 
-fn handle_command(command: &str, mut rest_args: Skip<Args>) {
+fn initial_task_list() -> Result<(), io::Error> {
+    if let Err(error) = TaskList::read_task_list(TASK_LIST_PATH) {
+        if error.kind() == ErrorKind::NotFound {
+            TaskList::create_empty_task_list(TASK_LIST_PATH)?;
+        }
+    }
+    Ok(())
+}
+
+fn execute_command(
+    command: &str,
+    mut rest_args: impl Iterator<Item = String>,
+) -> Result<(), io::Error> {
     match command {
         "add" => {
-            if let Some(description) = rest_args.nth(0) {
-                println!("{description}");
-                let mut tasks = TaskList::read_task_list();
-                let task_id = tasks.next_id();
-                tasks.add(&description);
-                println!("Task added successfully (ID: {})", task_id);
-            };
+            rest_args
+                .next()
+                .map(|description| {
+                    println!("{description}");
+                    TaskList::read_task_list(TASK_LIST_PATH).and_then(|mut tasks| {
+                        let task_id = tasks.next_id();
+                        tasks.add(&description);
+                        println!("Task added successfully (ID: {})", task_id);
+                        Ok(())
+                    })
+                })
+                .unwrap_or_else(|| {
+                    println!("No description provided...");
+                    Ok(())
+                })?;
         }
         "update" => {
-            if let Some(id) = rest_args.nth(0) {
-                if let Some(description) = rest_args.nth(1) {
-                    TaskList::read_task_list().update(id.parse().unwrap(), &description);
-                } else {
-                    panic!("No description provided...");
-                }
-            } else {
-                panic!("No ID provided...");
-            }
+            rest_args
+                .next()
+                .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "No ID provided..."))
+                .and_then(|id| {
+                    rest_args
+                        .next()
+                        .ok_or_else(|| {
+                            io::Error::new(
+                                io::ErrorKind::InvalidInput,
+                                "No description provided...",
+                            )
+                        })
+                        .and_then(|description| {
+                            let mut tasks = TaskList::read_task_list(TASK_LIST_PATH)?;
+                            tasks.update(id.parse().unwrap(), &description);
+                            Ok(())
+                        })
+                })?;
         }
         "delete" => {
-            if let Some(id) = rest_args.nth(0) {
-                TaskList::read_task_list().delete(id.parse().unwrap());
-            } else {
-                println!("No ID provided...");
-            }
+            rest_args
+                .next()
+                .map(|id| {
+                    TaskList::read_task_list(TASK_LIST_PATH).and_then(|mut task_list| {
+                        task_list.delete(id.parse().unwrap());
+                        Ok(())
+                    })
+                })
+                .unwrap_or_else(|| {
+                    println!("No ID provided...");
+                    Ok(())
+                })?;
         }
         "list" => {
-            if let Some(status) = rest_args.nth(0) {
-                let status = Status::from_str(&status);
-                TaskList::read_task_list()
-                    .list(Some(&status))
-                    .into_iter()
-                    .for_each(print_task);
-            } else {
-                TaskList::read_task_list()
-                    .list(None)
-                    .into_iter()
-                    .for_each(|task| print_task(task));
-            }
+            let status = rest_args.next().map(|status| Status::from_str(&status));
+            TaskList::read_task_list(TASK_LIST_PATH)?
+                .list(status.as_ref())
+                .into_iter()
+                .for_each(print_task);
         }
         "mark-in-progress" => {
-            if let Some(id) = rest_args.nth(0) {
-                TaskList::read_task_list().toggle_status(Status::InProgress, id.parse().unwrap());
-            }
+            rest_args
+                .next()
+                .map(|id| {
+                    TaskList::read_task_list(TASK_LIST_PATH).and_then(|mut task_list| {
+                        task_list.toggle_status(Status::InProgress, id.parse().unwrap());
+                        Ok(())
+                    })
+                })
+                .unwrap_or_else(|| {
+                    println!("No ID provided...");
+                    Ok(())
+                })?;
         }
         "mark-done" => {
-            if let Some(id) = rest_args.nth(0) {
-                TaskList::read_task_list().toggle_status(Status::Done, id.parse().unwrap());
-            }
+            rest_args
+                .next()
+                .map(|id| {
+                    TaskList::read_task_list(TASK_LIST_PATH).and_then(|mut task_list| {
+                        task_list.toggle_status(Status::Done, id.parse().unwrap());
+                        Ok(())
+                    })
+                })
+                .unwrap_or_else(|| {
+                    println!("No ID provided...");
+                    Ok(())
+                })?;
         }
         _ => {
             println!("Invalid command...");
         }
-    }
+    };
+    Ok(())
 }
 
 fn print_task(task: &Task) {

--- a/src/task_list.rs
+++ b/src/task_list.rs
@@ -1,28 +1,33 @@
 use super::task::{Status, Task};
 use serde_json;
 use std::fs::{self};
-use std::io::{self, ErrorKind};
-const TASKS_FILE: &str = "tasks.json";
+use std::io::{self};
 
 pub struct TaskList {
     tasks: Vec<Task>,
     next_id: u32,
+    path: String,
 }
 
 impl TaskList {
-    fn new() -> Self {
+    fn new(path: String) -> Self {
         Self {
             tasks: Vec::<Task>::new(),
             next_id: 1,
+            path,
         }
     }
 
-    fn build(tasks: Vec<Task>) -> Self {
+    fn build(tasks: Vec<Task>, path: String) -> Self {
         if tasks.is_empty() {
-            return Self::new();
+            return Self::new(path);
         }
         let next_id = tasks.last().unwrap().id() + 1;
-        Self { tasks, next_id }
+        Self {
+            tasks,
+            next_id,
+            path,
+        }
     }
 
     pub fn next_id(&self) -> u32 {
@@ -33,13 +38,13 @@ impl TaskList {
         let task = Task::new(self.next_id, description);
         self.tasks.push(task);
         self.next_id += 1;
-        let _ = Self::write_task_list(&self.tasks);
+        self.write_into().unwrap();
     }
 
     pub fn update(&mut self, id: u32, description: &str) -> bool {
         if let Some(task) = self.get(id) {
             task.set_description(description);
-            let _ = Self::write_task_list(&self.tasks);
+            self.write_into().unwrap();
             return true;
         }
         false
@@ -48,7 +53,7 @@ impl TaskList {
     pub fn toggle_status(&mut self, status: Status, id: u32) -> bool {
         if let Some(task) = self.get(id) {
             task.set_status(status);
-            let _ = Self::write_task_list(&self.tasks);
+            self.write_into().unwrap();
             return true;
         }
         false
@@ -57,7 +62,7 @@ impl TaskList {
     pub fn delete(&mut self, id: u32) -> bool {
         if let Some(index) = self.position(id) {
             self.tasks.remove(index);
-            let _ = Self::write_task_list(&self.tasks);
+            self.write_into().unwrap();
             return true;
         }
         false
@@ -82,74 +87,286 @@ impl TaskList {
         }
     }
 
-    fn write_task_list(tasks: &Vec<Task>) -> Result<(), io::Error> {
-        let content = serde_json::to_string(&tasks)?;
-        fs::write(TASKS_FILE, content)?;
+    fn write_into(&self) -> Result<(), io::Error> {
+        let content = serde_json::to_string(&self.tasks)?;
+        fs::write(&self.path, content)?;
         Ok(())
     }
 
-    pub fn read_task_list() -> TaskList {
-        match fs::read_to_string(TASKS_FILE) {
-            Ok(contents) => {
-                if let Ok(tasks) = serde_json::from_str(&contents) {
-                    Self::build(tasks)
-                } else {
-                    panic!("Error parsing tasks file...");
-                }
-            }
-            Err(error) => match error.kind() {
-                ErrorKind::NotFound => {
-                    let _ = fs::write(TASKS_FILE, "[]");
-                    Self::new()
-                }
-                _ => panic!("Error reading tasks file: {:?}", error),
-            },
-        }
+    pub fn create_empty_task_list(tasks_file_path: &str) -> Result<Self, io::Error> {
+        fs::write(tasks_file_path, "[]")?;
+        Ok(Self::new(tasks_file_path.to_string()))
+    }
+
+    pub fn read_task_list(tasks_file_path: &str) -> Result<TaskList, io::Error> {
+        let contents = fs::read_to_string(tasks_file_path)?;
+
+        let tasks = serde_json::from_str(&contents)?;
+        Ok(Self::build(tasks, tasks_file_path.to_string()))
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    const TEST_TASKS_FILE: &str = ".tasks_test.json";
 
-    #[test]
-    fn test_first_read_task_list() {
-        let _ = fs::remove_file(TASKS_FILE);
-        let tasks = TaskList::read_task_list().tasks;
-        assert_eq!(tasks, Vec::<Task>::new());
+    fn setup_empty() -> TaskList {
+        let _ = fs::remove_file(TEST_TASKS_FILE);
+        let task_list = TaskList::create_empty_task_list(TEST_TASKS_FILE).unwrap();
+        task_list
+    }
+
+    fn setup_with_tasks() -> TaskList {
+        let _ = fs::remove_file(TEST_TASKS_FILE);
+        let tasks = vec![
+            Task::new(1, "Leetcode"),
+            Task::new(2, "Backend"),
+            Task::new(3, "Frontend"),
+        ];
+        let task_list = TaskList::build(tasks, TEST_TASKS_FILE.to_string());
+        task_list.write_into().unwrap();
+        task_list
+    }
+
+    fn teardown() {
+        let _ = fs::remove_file(TEST_TASKS_FILE);
     }
 
     #[test]
-    fn test_add_task() {
-        let mut task_list = TaskList::read_task_list();
-        task_list.add("testing");
-        let new_tasks = TaskList::read_task_list();
-        assert_eq!(task_list.tasks.len(), new_tasks.tasks.len())
+    fn create_new_task_list() {
+        teardown();
+        let new_file_path = TEST_TASKS_FILE;
+        let task_list = TaskList::create_empty_task_list(new_file_path).unwrap();
+
+        assert!(fs::metadata(new_file_path).is_ok());
+
+        assert_eq!(task_list.tasks.len(), 0);
+        assert_eq!(task_list.next_id, 1);
+        assert_eq!(task_list.path, new_file_path);
+
+        teardown();
     }
 
     #[test]
-    fn test_delete_task() {
-        let mut task_list = TaskList::read_task_list();
-        task_list.delete(1);
+    fn test_build_empty_tasks() {
+        let tasks = Vec::<Task>::new();
+        let task_list = TaskList::build(tasks, "path".to_string());
+
+        assert_eq!(task_list.next_id, 1);
         assert_eq!(task_list.tasks.len(), 0);
     }
 
     #[test]
-    fn test_update_task() {
-        let mut task_list = TaskList::read_task_list();
-        task_list.add("testing");
-        task_list.update(1, "updated");
-        let task = task_list.tasks.iter().find(|task| task.id() == 1).unwrap();
-        assert_eq!(task.description(), "updated");
+    fn test_build_with_tasks() {
+        let tasks = vec![
+            Task::new(1, "Task 1"),
+            Task::new(2, "Task 2"),
+            Task::new(3, "Task 3"),
+        ];
+
+        let task_list = TaskList::build(tasks, "path".to_string());
+
+        assert_eq!(task_list.next_id, 4);
+        assert_eq!(task_list.tasks.len(), 3);
     }
 
     #[test]
-    fn test_list_tasks() {
-        let mut task_list = TaskList::read_task_list();
-        task_list.add("testing");
-        task_list.add("testing");
-        task_list.add("testing");
+    fn test_read_write_task_list() {
+        let tasks = vec![
+            Task::new(1, "Leetcode"),
+            Task::new(2, "Backend"),
+            Task::new(3, "Frontend"),
+        ];
+        let original = TaskList::build(tasks, TEST_TASKS_FILE.to_string());
+        original.write_into().unwrap();
+
+        let from_file = TaskList::read_task_list(TEST_TASKS_FILE).unwrap();
+        assert_eq!(original.tasks.len(), from_file.tasks.len());
+        assert_eq!(original.next_id, from_file.next_id);
+
+        for i in 0..original.tasks.len() {
+            assert_eq!(original.tasks[i].id(), from_file.tasks[i].id());
+            assert_eq!(
+                original.tasks[i].description(),
+                from_file.tasks[i].description()
+            );
+            assert_eq!(original.tasks[i].status(), from_file.tasks[i].status());
+        }
+
+        teardown();
+    }
+
+    #[test]
+    fn test_first_read_task_list_empty_file() {
+        TaskList::create_empty_task_list(TEST_TASKS_FILE).unwrap();
+
+        let task_list = TaskList::read_task_list(TEST_TASKS_FILE).unwrap();
+        assert_eq!(task_list.tasks.len(), 0);
+        assert_eq!(task_list.next_id, 1);
+
+        teardown();
+    }
+
+    #[test]
+    fn test_add_task() {
+        let mut task_list = setup_empty();
+
+        task_list.add("First task");
+        assert_eq!(task_list.tasks.len(), 1);
+        assert_eq!(task_list.next_id, 2);
+        assert_eq!(task_list.tasks[0].description(), "First task");
+        assert_eq!(task_list.tasks[0].id(), 1);
+
+        task_list.add("Second task");
+        assert_eq!(task_list.tasks.len(), 2);
+        assert_eq!(task_list.next_id, 3);
+
+        let from_file = TaskList::read_task_list(TEST_TASKS_FILE).unwrap();
+        assert_eq!(from_file.tasks.len(), 2);
+
+        teardown();
+    }
+
+    #[test]
+    fn test_get_task() {
+        let mut task_list = setup_with_tasks();
+
+        let task = task_list.get(2);
+        assert!(task.is_some());
+        assert_eq!(task.unwrap().description(), "Backend");
+
+        let task = task_list.get(99);
+        assert!(task.is_none());
+
+        teardown();
+    }
+
+    #[test]
+    fn test_update_task_success() {
+        let mut task_list = setup_with_tasks();
+
+        let result = task_list.update(2, "Updated Backend");
+        assert!(result);
+
+        let task = task_list.get(2).unwrap();
+        assert_eq!(task.description(), "Updated Backend");
+
+        let from_file = TaskList::read_task_list(TEST_TASKS_FILE).unwrap();
+        let task = from_file.tasks.iter().find(|t| t.id() == 2).unwrap();
+        assert_eq!(task.description(), "Updated Backend");
+
+        teardown();
+    }
+
+    #[test]
+    fn test_update_task_failure() {
+        let mut task_list = setup_with_tasks();
+
+        let result = task_list.update(99, "Does not exist");
+        assert!(!result);
+
+        teardown();
+    }
+
+    #[test]
+    fn test_toggle_status() {
+        let mut task_list = setup_with_tasks();
+
+        let result = task_list.toggle_status(Status::InProgress, 2);
+        assert!(result);
+
+        let task = task_list.get(2).unwrap();
+        assert_eq!(task.status(), &Status::InProgress);
+
+        let result = task_list.toggle_status(Status::Done, 2);
+        assert!(result);
+
+        let task = task_list.get(2).unwrap();
+        assert_eq!(task.status(), &Status::Done);
+
+        let result = task_list.toggle_status(Status::Done, 99);
+        assert!(!result);
+
+        teardown();
+    }
+
+    #[test]
+    fn test_delete_task_success() {
+        let mut task_list = setup_with_tasks();
+        assert_eq!(task_list.tasks.len(), 3);
+
+        let result = task_list.delete(2);
+        assert!(result);
+        assert_eq!(task_list.tasks.len(), 2);
+
+        let from_file = TaskList::read_task_list(TEST_TASKS_FILE).unwrap();
+        assert_eq!(from_file.tasks.len(), 2);
+        assert!(from_file.tasks.iter().find(|t| t.id() == 2).is_none());
+
+        teardown();
+    }
+
+    #[test]
+    fn test_delete_task_failure() {
+        let mut task_list = setup_with_tasks();
+        assert_eq!(task_list.tasks.len(), 3);
+
+        let result = task_list.delete(99);
+        assert!(!result);
+        assert_eq!(task_list.tasks.len(), 3);
+
+        teardown();
+    }
+
+    #[test]
+    fn test_list_all_tasks() {
+        let task_list = setup_with_tasks();
+
         let tasks = task_list.list(None);
         assert_eq!(tasks.len(), 3);
+
+        teardown();
+    }
+
+    #[test]
+    fn test_list_filtered_by_status() {
+        let mut task_list = setup_with_tasks();
+
+        let todo_tasks = task_list.list(Some(&Status::Todo));
+        assert_eq!(todo_tasks.len(), 3);
+
+        task_list.toggle_status(Status::InProgress, 2);
+
+        let todo_tasks = task_list.list(Some(&Status::Todo));
+        let in_progress_tasks = task_list.list(Some(&Status::InProgress));
+        let done_tasks = task_list.list(Some(&Status::Done));
+
+        assert_eq!(todo_tasks.len(), 2);
+        assert_eq!(in_progress_tasks.len(), 1);
+        assert_eq!(done_tasks.len(), 0);
+
+        teardown();
+    }
+
+    #[test]
+    fn test_position() {
+        let task_list = setup_with_tasks();
+
+        let pos = task_list.position(2);
+        assert_eq!(pos, Some(1));
+        let pos = task_list.position(99);
+        assert_eq!(pos, None);
+
+        teardown();
+    }
+
+    #[test]
+    fn test_next_id() {
+        let task_list = setup_with_tasks();
+
+        assert_eq!(task_list.next_id(), 4);
+
+        teardown();
     }
 }


### PR DESCRIPTION
 - 重寫 `TaskList` method 錯誤處理方式
 - `TaskList` 新增 `path` 欄位可指定檔案儲存位置
 - 新增測試程式